### PR TITLE
Fixing issue where redLock expects array and we pass string

### DIFF
--- a/server/register.js
+++ b/server/register.js
@@ -16,7 +16,7 @@ module.exports = ({ strapi }) => {
 
         let lock
         try {
-          lock = await redlock.acquire(name, config.lockTTL)
+          lock = await redlock.acquire([name], config.lockTTL)
           debug(`Job ${name} acquired lock`)
           await originalFunction(...args)
         } catch (e) {


### PR DESCRIPTION
## Description 
Fixes issue described here:
https://github.com/excl-networks/strapi-plugin-redcron/issues/2